### PR TITLE
Support umap-learn v0.5+

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/pegasus/tools/visualization.py
+++ b/pegasus/tools/visualization.py
@@ -162,7 +162,15 @@ def calc_umap(
         _n_epochs = umap_obj.n_epochs if umap_obj.n_epochs is not None else 0
         if umap_obj.verbose:
             logger.info("Construct embedding")
-        embedding = umap_module.umap_.simplicial_set_embedding(
+
+        def simplicial_set_embedding(*args, **kwargs):
+            from packaging import version
+            if version.parse(umap_module.__version__) >= version.parse('0.5.0'): # For umap-learn v0.5+
+                kwargs.update({'densmap': False, 'densmap_kwds': {}, 'output_dens': False})
+            embedding = umap_module.umap_.simplicial_set_embedding(*args, **kwargs)
+            return (embedding[0] if isinstance(embedding, tuple) else embedding)
+
+        embedding = simplicial_set_embedding(
             data=X,
             graph=umap_obj.graph_,
             n_components=umap_obj.n_components,
@@ -251,7 +259,7 @@ def tsne(
 
     learning_rate: ``float``, optional, default: ``auto``
         By default, the learning rate is determined automatically as max(data.shape[0] / early_exaggeration, 200). See [Belkina19]_ and [Kobak19]_ for details.
-    
+
     initialization: ``str``, optional, default: ``pca``
         Initialization can be either ``pca`` or ``random`` or np.ndarray. By default, we use ``pca`` initialization according to [Kobak19]_.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ loompy
 louvain>=0.7.0
 matplotlib>=2.0.0
 natsort
-numba<=0.52.0
+numba
 numpy
 pandas>=1.2.0
 pegasusio>=0.2.9
@@ -30,5 +30,5 @@ seaborn
 setuptools
 statsmodels
 torch
-umap-learn>=0.4, <0.5
+umap-learn>=0.4
 xlsxwriter

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     keywords="single cell/nucleus genomics analysis",
     packages=find_packages(),


### PR DESCRIPTION
Besides, there is no more restriction on `numba` version, which makes Pegasus support Python 3.9 naturally.